### PR TITLE
Add pilot compliance benchmark and statutory judgment rubric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,9 +37,13 @@ prisma/migrations/*.sql.bak
 .cursor/
 .claude/
 
-docs/
+docs/*
+!docs/eval-pilot-report.md
 
 # Database dumps
 data/rta-chunks.sql
 
 files/
+
+# Private benchmark artifacts
+private_eval/

--- a/docs/eval-pilot-report.md
+++ b/docs/eval-pilot-report.md
@@ -1,0 +1,61 @@
+# LeaseLens Pilot Benchmark Report (Scope A)
+
+**Date:** 2026-07-02 · **Runs:** `pilot_001` (baseline), `pilot_002` (retrieval experiment, reverted), `pilot_003` (final production configuration), `pilot_004` (model tier study), `pilot_005` (calibration experiment, reverted) · **Pipeline:** router (gpt-4o-mini) → hybrid RAG retrieval (pgvector plus full text search, RRF, top 5) → structured judgment (gpt-4o-mini) with `compliance_normalization_v1` post processing.
+
+This report contains aggregate metrics only. No lease text, document identifiers, or personal information appear here; per sample records live in `private_eval/` and are never published.
+
+## Dataset
+
+39 clauses extracted from real Ontario lease PDFs (private source), spanning 11 legal scenarios (repair duty waivers, prohibited charges, rent deposits, postdated cheques, entry rights, pet bans, termination documents required at signing, assignment and sublet consent, lock changes, guest damage). Every row was reviewed by a human: the gold compliance label, the expected product label, and the gold statute citations were adjudicated against the text of the Residential Tenancies Act, 2006. Spans with parser segmentation defects (truncated or merged clauses, struck through text, page footer contamination) were excluded during review rather than patched.
+
+## The three questions
+
+| Question | Metric | Baseline (pilot_001) | Final (pilot_003) |
+|---|---|---|---|
+| Does LeaseLens find the right RTA authority? | Retrieval section hit rate (gold section in top 5) | 69.2% | 69.2% |
+| Does it cite the correct legal section? | Citation hit rate (gold section among cited references) | 59.0% | **66.7%** |
+| Does it give a reasonable legal verdict? | Verdict accuracy against human gold | 46.2% | **59.0%** |
+
+Supporting numbers (pilot_003): router category accuracy 66.7%, mean latency 4.1 s (p95 6.8 s), cost per full run about $0.018, zero failed samples in every run.
+
+Because the product decision is binary in practice (flag the clause or let it pass), we also track flag metrics. Final configuration: problem clause recall 76.0% (up from 36.0% at baseline), flag precision 76.0% (from 69.2%), and zero cases of an illegal clause judged compliant (down from 5 at baseline).
+
+## What changed between baseline and final
+
+**Judgment rubric (kept).** The baseline confusion matrix showed a strong leniency bias: 11 of 16 needs_review golds and 5 of 9 non_compliant golds were predicted compliant. We codified a statutory decision rubric into the analysis system prompt: clauses that impose, waive, or transfer duties the Act reserves are non_compliant (RTA ss. 3 and 4 make contracted out provisions void regardless of consent); clauses whose legality turns on facts outside the clause are needs_review; clauses that restate the Act (tenant duties under ss. 33 and 34) are compliant. The advance rent guidance was also corrected to match s. 106(2). Effect: non_compliant recall rose from 3 of 9 to 8 of 9, overall verdict accuracy 46.2% → 59.0%, citation accuracy 59.0% → 66.7%. The rubric was derived from the structure of the statute, not from inspecting failed samples.
+
+**Soft category retrieval (tested, reverted).** Hypothesis: the hard `WHERE category =` filter blinds retrieval when the router misclassifies (router accuracy is 66.7%). We tested fusing corpus wide and category scoped searches, turning the category into a soft boost. Result: net zero. Two samples gained, two lost; rows with a misclassified router were rescued, but rows with a correct router lost the noise suppression benefit of the hard filter. The change was reverted. Deeper analysis showed the remaining retrieval misses are a semantic gap problem: for example, utility transfer clauses embed far from the fee enumeration language of s. 134, so the top ranks fill with semantically closer utility apportionment sections (ss. 137 and 138).
+
+## Model tier tradeoff (measured, production unchanged)
+
+`pilot_004` re-ran the final configuration with gpt-4o as the analysis model (router and retrieval unchanged):
+
+| Metric | gpt-4o-mini (pilot_003) | gpt-4o (pilot_004) |
+|---|---|---|
+| Verdict accuracy | 59.0% | **69.2%** |
+| Flag precision | 76.0% | **82.6%** |
+| Problem clause recall | 76.0% | 76.0% |
+| Illegal clauses judged compliant | 0 | 0 |
+| Citation hit rate | 66.7% | 61.5% (within noise) |
+| Mean latency | 4.1 s | 3.9 s |
+| Cost per full run | $0.018 | $0.275 |
+
+The larger model buys about 10 points of verdict accuracy and 7 points of precision at roughly 15 times the inference cost, with no recall gain. Production stays on gpt-4o-mini for cost reasons; the tradeoff is documented here for a future capacity decision.
+
+## Verdict calibration experiment (tested, reverted)
+
+`pilot_005` added a symmetric instruction to the rubric ("do not invent violations") aimed at the 5 false non_compliant verdicts. On gpt-4o-mini it backfired: precision fell to 73.9%, recall fell to 68.0%, and one illegal clause slipped through as compliant again. The softening language re-opened the leniency the rubric had closed, so the change was reverted. Calibrating the aggressive edge appears to require the stronger model (gpt-4o reached 82.6% precision with no prompt change) rather than prompt softening.
+
+## Remaining known gaps
+
+- Verdict calibration now leans slightly aggressive, the mirror image of the leniency fix: 5 of 14 compliant golds are predicted non_compliant. Prompt softening made this worse (see the calibration experiment); the measured paths forward are the model tier upgrade or richer few shot guidance.
+- Retrieval for fee and charge clauses (the s. 134 family) needs a semantic bridge (section content enrichment or query expansion), not filter tuning.
+- Entry notice scenarios score 0 of 3 on verdict: gold treats informal notice showing clauses as needs_review, while the model splits between compliant and non_compliant.
+
+## Limitations
+
+- Scope A only (legal correctness benchmark); no security or adversarial evaluation yet.
+- Pilot scale: n = 39; per scenario counts are small (1 to 14), so scenario level rates are indicative only.
+- A single human reviewer produced the gold labels (adjudicated against statute text; no agreement between annotators measured).
+- Single run per configuration; no variance across repeated runs measured. Analysis temperature is 0.2, so figures may move by roughly one sample between runs.
+- Private real PDF source; the dataset cannot be published, only aggregate results.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "eval:pilot:run": "npx tsx scripts/eval-pilot-run.ts"
   },
   "dependencies": {
     "@ai-sdk/openai": "^1.3.24",

--- a/scripts/eval-pilot-run.ts
+++ b/scripts/eval-pilot-run.ts
@@ -1,0 +1,343 @@
+import { promises as fs } from "fs"
+import path from "path"
+import { execSync } from "child_process"
+import dotenv from "dotenv"
+
+dotenv.config({ path: ".env.local" })
+
+// Pilot benchmark runner: replays the production per-clause pipeline
+// (categorize -> hybrid retrieve -> analyze) over the pilot dataset and
+// scores retrieval, citations, and labels against human gold.
+// Usage: npx tsx scripts/eval-pilot-run.ts [--limit N] [--run pilot_001]
+
+const DATASET = "private_eval/datasets/lease_eval_pilot.jsonl"
+const RUNS_DIR = "private_eval/runs"
+const TOP_K = 5
+
+// Pricing per 1M tokens (2026-07 OpenAI list prices), keyed by model id
+const MODEL_PRICES_PER_M: Record<string, { input: number; output: number }> = {
+  "gpt-4o-mini": { input: 0.15, output: 0.6 },
+  "gpt-4o": { input: 2.5, output: 10.0 },
+}
+const ROUTER_MODEL_ID = "gpt-4o-mini"
+const EMBED_PER_M = 0.02
+
+interface PilotRow {
+  sample_id: string
+  scenario_id: string
+  gold_router_category: string
+  normalized_clause_text: string
+  gold_section_ids: string[]
+  legal_gold_label: string
+  product_expected_label: string
+}
+
+interface SampleRecord {
+  sample_id: string
+  scenario_id: string
+  clause_text: string
+  gold_router_category: string
+  predicted_category: string | null
+  router_correct: boolean | null
+  gold_section_ids: string[]
+  retrieved_section_keys: string[]
+  retrieval_hit: boolean | null
+  citations_raw: string[]
+  cited_section_keys: string[]
+  citation_hit: boolean | null
+  gold_legal_label: string
+  product_expected_label: string
+  predicted_label: string | null
+  label_match_product: boolean | null
+  label_match_legal: boolean | null
+  latency_ms: { router: number; retrieval: number; analysis: number; total: number }
+  tokens: { router_prompt: number; router_completion: number; analysis_prompt: number; analysis_completion: number }
+  error: string | null
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2)
+  let limit = Infinity
+  let runName: string | null = null
+  for (let i = 0; i < args.length; i += 1) {
+    if (args[i] === "--limit") limit = Number(args[i + 1])
+    if (args[i] === "--run") runName = args[i + 1]
+  }
+  return { limit, runName }
+}
+
+async function nextRunName() {
+  await fs.mkdir(RUNS_DIR, { recursive: true })
+  const existing = await fs.readdir(RUNS_DIR)
+  for (let i = 1; i < 1000; i += 1) {
+    const name = `pilot_${String(i).padStart(3, "0")}`
+    if (!existing.includes(name)) return name
+  }
+  throw new Error("no free run name")
+}
+
+function keyMatchesGold(goldKey: string, candidateKey: string) {
+  const [goldSource, goldSection, goldSub] = goldKey.split("|")
+  const [candSource, candSection, candSub = ""] = candidateKey.split("|")
+  return goldSource === candSource && goldSection === candSection && (goldSub === "" || goldSub === candSub)
+}
+
+function anyGoldMatch(goldKeys: string[], candidateKeys: string[]) {
+  return goldKeys.some((gold) => candidateKeys.some((candidate) => keyMatchesGold(gold, candidate)))
+}
+
+function parseCitationKeys(citation: string): string[] {
+  if (!/rta|residential tenancies/i.test(citation)) return []
+  const keys: string[] = []
+  const re = /ss?\.?\s*(\d+(?:\.\d+)?)\s*(?:\((\d+(?:\.\d+)?[a-z]?)\))?/gi
+  let match
+  while ((match = re.exec(citation)) !== null) {
+    keys.push(`RTA|${match[1]}|${match[2] ?? ""}`)
+  }
+  return keys
+}
+
+function percentile(sorted: number[], p: number) {
+  if (sorted.length === 0) return 0
+  const index = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1)
+  return sorted[Math.max(0, index)]
+}
+
+function rate(numerator: number, denominator: number) {
+  return denominator === 0 ? null : Number((numerator / denominator).toFixed(4))
+}
+
+async function main() {
+  const { limit, runName } = parseArgs()
+  const { categorizeClauseWithUsage } = await import("@/lib/clause-extractor")
+  const { hybridSearch } = await import("@/lib/rag")
+  const { analyzeClauseWithUsage } = await import("@/lib/llm")
+  const { prisma } = await import("@/lib/prisma")
+  const { analysisModelConfig } = await import("@/config/llm")
+
+  const analysisModelId = analysisModelConfig.model.modelId
+  const analysisPrices = MODEL_PRICES_PER_M[analysisModelId]
+  const routerPrices = MODEL_PRICES_PER_M[ROUTER_MODEL_ID]
+  if (!analysisPrices) {
+    throw new Error(`no pricing configured for analysis model ${analysisModelId}`)
+  }
+
+  const rows = (await fs.readFile(DATASET, "utf8"))
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as PilotRow)
+    .slice(0, limit)
+
+  const run = runName ?? (await nextRunName())
+  const runDir = path.join(RUNS_DIR, run)
+  await fs.mkdir(runDir, { recursive: true })
+
+  console.log(`run ${run}: ${rows.length} samples from ${DATASET}`)
+
+  const records: SampleRecord[] = []
+  const errors: Array<{ sample_id: string; stage: string; error: string }> = []
+
+  for (const [index, row] of rows.entries()) {
+    const clause = row.normalized_clause_text
+    const record: SampleRecord = {
+      sample_id: row.sample_id,
+      scenario_id: row.scenario_id,
+      clause_text: clause,
+      gold_router_category: row.gold_router_category,
+      predicted_category: null,
+      router_correct: null,
+      gold_section_ids: row.gold_section_ids,
+      retrieved_section_keys: [],
+      retrieval_hit: null,
+      citations_raw: [],
+      cited_section_keys: [],
+      citation_hit: null,
+      gold_legal_label: row.legal_gold_label,
+      product_expected_label: row.product_expected_label,
+      predicted_label: null,
+      label_match_product: null,
+      label_match_legal: null,
+      latency_ms: { router: 0, retrieval: 0, analysis: 0, total: 0 },
+      tokens: { router_prompt: 0, router_completion: 0, analysis_prompt: 0, analysis_completion: 0 },
+      error: null,
+    }
+
+    const t0 = Date.now()
+    let stage = "router"
+    try {
+      const routerOut = await categorizeClauseWithUsage(clause)
+      record.latency_ms.router = Date.now() - t0
+      record.predicted_category = routerOut.category
+      record.router_correct = routerOut.category === row.gold_router_category
+      record.tokens.router_prompt = routerOut.usage.promptTokens ?? 0
+      record.tokens.router_completion = routerOut.usage.completionTokens ?? 0
+
+      stage = "retrieval"
+      const t1 = Date.now()
+      const hits = await hybridSearch(clause, { topK: TOP_K, category: routerOut.category })
+      record.latency_ms.retrieval = Date.now() - t1
+      const chunkRows = await prisma.rtaChunk.findMany({
+        where: { id: { in: hits.map((hit) => hit.id) } },
+        select: { id: true, source: true, section: true, subsection: true },
+      })
+      const keyById = new Map(chunkRows.map((chunk) => [chunk.id, `${chunk.source}|${chunk.section}|${chunk.subsection ?? ""}`]))
+      record.retrieved_section_keys = hits.map((hit) => keyById.get(hit.id) ?? `unknown|${hit.section}|`)
+      record.retrieval_hit = anyGoldMatch(row.gold_section_ids, record.retrieved_section_keys)
+
+      stage = "analysis"
+      const t2 = Date.now()
+      const context = hits.map((hit) => `[${hit.fullCitation}] ${hit.content}`)
+      const analysisOut = await analyzeClauseWithUsage(clause, context)
+      record.latency_ms.analysis = Date.now() - t2
+      record.predicted_label = analysisOut.result.status
+      record.label_match_product = analysisOut.result.status === row.product_expected_label
+      record.label_match_legal = analysisOut.result.status === row.legal_gold_label
+      record.citations_raw = analysisOut.result.citations
+      record.cited_section_keys = Array.from(new Set(analysisOut.result.citations.flatMap(parseCitationKeys)))
+      record.citation_hit = anyGoldMatch(row.gold_section_ids, record.cited_section_keys)
+      record.tokens.analysis_prompt = analysisOut.usage.promptTokens ?? 0
+      record.tokens.analysis_completion = analysisOut.usage.completionTokens ?? 0
+    } catch (error) {
+      record.error = `${stage}: ${error instanceof Error ? error.message : String(error)}`
+      errors.push({ sample_id: row.sample_id, stage, error: record.error })
+    }
+    record.latency_ms.total = Date.now() - t0
+    records.push(record)
+
+    console.log(
+      `${String(index + 1).padStart(2)}/${rows.length} ${row.sample_id} ` +
+        (record.error
+          ? `ERROR ${record.error.slice(0, 60)}`
+          : `label=${record.predicted_label}(gold ${row.product_expected_label}) retr=${record.retrieval_hit ? "hit" : "miss"} cite=${record.citation_hit ? "hit" : "miss"} ${record.latency_ms.total}ms`),
+    )
+  }
+
+  const scored = records.filter((record) => record.error === null)
+  const latencies = scored.map((record) => record.latency_ms.total).sort((a, b) => a - b)
+  const analysisPrompt = scored.reduce((sum, record) => sum + record.tokens.analysis_prompt, 0)
+  const analysisCompletion = scored.reduce((sum, record) => sum + record.tokens.analysis_completion, 0)
+  const routerPrompt = scored.reduce((sum, record) => sum + record.tokens.router_prompt, 0)
+  const routerCompletion = scored.reduce((sum, record) => sum + record.tokens.router_completion, 0)
+  const embedTokensEstimate = Math.ceil(scored.reduce((sum, record) => sum + record.clause_text.length, 0) / 4)
+  const costUsd =
+    (analysisPrompt / 1e6) * analysisPrices.input +
+    (analysisCompletion / 1e6) * analysisPrices.output +
+    (routerPrompt / 1e6) * routerPrices.input +
+    (routerCompletion / 1e6) * routerPrices.output +
+    (embedTokensEstimate / 1e6) * EMBED_PER_M
+
+  const isFlagged = (label: string | null) => label === "needs_review" || label === "non_compliant"
+  const flagTruePositive = scored.filter((r) => isFlagged(r.product_expected_label) && isFlagged(r.predicted_label)).length
+  const flagFalsePositive = scored.filter((r) => !isFlagged(r.product_expected_label) && isFlagged(r.predicted_label)).length
+  const flagFalseNegative = scored.filter((r) => isFlagged(r.product_expected_label) && !isFlagged(r.predicted_label)).length
+  const flagTrueNegative = scored.filter((r) => !isFlagged(r.product_expected_label) && !isFlagged(r.predicted_label)).length
+  const dangerousMissCount = scored.filter((r) => r.product_expected_label === "non_compliant" && r.predicted_label === "compliant").length
+
+  const confusion: Record<string, Record<string, number>> = {}
+  for (const record of scored) {
+    const gold = record.product_expected_label
+    const pred = record.predicted_label ?? "none"
+    confusion[gold] = confusion[gold] ?? {}
+    confusion[gold][pred] = (confusion[gold][pred] ?? 0) + 1
+  }
+
+  const scenarioIds = Array.from(new Set(scored.map((record) => record.scenario_id))).sort()
+  const perScenario = Object.fromEntries(
+    scenarioIds.map((scenarioId) => {
+      const subset = scored.filter((record) => record.scenario_id === scenarioId)
+      return [scenarioId, {
+        n: subset.length,
+        label_accuracy_product: rate(subset.filter((r) => r.label_match_product).length, subset.length),
+        retrieval_hit_rate: rate(subset.filter((r) => r.retrieval_hit).length, subset.length),
+        citation_hit_rate: rate(subset.filter((r) => r.citation_hit).length, subset.length),
+      }]
+    }),
+  )
+
+  const summary = {
+    run_id: run,
+    generated_at_utc: new Date().toISOString(),
+    dataset: { path: DATASET, rows: rows.length },
+    samples_total: records.length,
+    samples_scored: scored.length,
+    samples_failed: errors.length,
+    metrics: {
+      retrieval_section_hit_rate: rate(scored.filter((r) => r.retrieval_hit).length, scored.length),
+      citation_hit_rate: rate(scored.filter((r) => r.citation_hit).length, scored.length),
+      label_accuracy_vs_product_expected: rate(scored.filter((r) => r.label_match_product).length, scored.length),
+      label_accuracy_vs_legal_gold: rate(scored.filter((r) => r.label_match_legal).length, scored.length),
+      router_category_accuracy: rate(scored.filter((r) => r.router_correct).length, scored.length),
+      flag_precision: rate(flagTruePositive, flagTruePositive + flagFalsePositive),
+      flag_recall: rate(flagTruePositive, flagTruePositive + flagFalseNegative),
+      binary_flag_accuracy: rate(flagTruePositive + flagTrueNegative, scored.length),
+      dangerous_miss_count: dangerousMissCount,
+    },
+    label_confusion_product_gold_vs_predicted: confusion,
+    per_scenario: perScenario,
+    latency_ms: {
+      avg: latencies.length ? Math.round(latencies.reduce((a, b) => a + b, 0) / latencies.length) : 0,
+      p50: percentile(latencies, 50),
+      p95: percentile(latencies, 95),
+    },
+    tokens: {
+      analysis_prompt: analysisPrompt,
+      analysis_completion: analysisCompletion,
+      router_prompt: routerPrompt,
+      router_completion: routerCompletion,
+      embedding_estimated: embedTokensEstimate,
+    },
+    estimated_cost_usd: Number(costUsd.toFixed(4)),
+    privacy_note: "This summary contains no lease text and is safe to publish. sample_records.jsonl is private.",
+  }
+
+  let gitCommit = "unknown"
+  try {
+    gitCommit = execSync("git rev-parse HEAD", { encoding: "utf8" }).trim()
+  } catch { /* not fatal */ }
+
+  const manifest = {
+    run_id: run,
+    generated_at_utc: summary.generated_at_utc,
+    dataset_path: DATASET,
+    dataset_rows: rows.length,
+    limit_applied: Number.isFinite(limit) ? limit : null,
+    pipeline: {
+      router_model: ROUTER_MODEL_ID,
+      analysis_model: analysisModelId,
+      embedding_model: "text-embedding-3-small",
+      retrieval: `hybrid vector + keyword with RRF, category filtered, topK ${TOP_K}`,
+      normalization: "compliance_normalization_v1 (production post processing kept)",
+    },
+    scoring: {
+      retrieval_hit: "any gold section key matched by a retrieved chunk key (section level match when gold has no subsection)",
+      citation_hit: "any gold section key matched by a key parsed from model citation strings",
+      label_reference: "product_expected_label primary, legal_gold_label also reported",
+    },
+    pricing_per_million_tokens_usd: {
+      analysis_model: analysisModelId,
+      analysis_input: analysisPrices.input,
+      analysis_output: analysisPrices.output,
+      router_input: routerPrices.input,
+      router_output: routerPrices.output,
+      embedding: EMBED_PER_M,
+    },
+    git_commit: gitCommit,
+    repeats: 1,
+  }
+
+  await fs.writeFile(path.join(runDir, "run_manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`)
+  await fs.writeFile(path.join(runDir, "sample_records.jsonl"), records.map((record) => JSON.stringify(record)).join("\n") + "\n")
+  await fs.writeFile(path.join(runDir, "summary.json"), `${JSON.stringify(summary, null, 2)}\n`)
+  await fs.writeFile(path.join(runDir, "errors.jsonl"), errors.length ? errors.map((error) => JSON.stringify(error)).join("\n") + "\n" : "")
+
+  console.log(`\nwrote ${runDir}/{run_manifest.json, sample_records.jsonl, summary.json, errors.jsonl}`)
+  console.log(JSON.stringify(summary.metrics, null, 2))
+  console.log(`latency avg ${summary.latency_ms.avg}ms p95 ${summary.latency_ms.p95}ms, est cost $${summary.estimated_cost_usd}`)
+
+  await prisma.$disconnect()
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/src/config/llm.ts
+++ b/src/config/llm.ts
@@ -46,6 +46,14 @@ Given a lease clause and relevant legal context, determine whether the clause is
 
 Be precise, cite section numbers, and avoid speculation.
 
+Decision rubric — apply these tests in order:
+
+1. "non_compliant" — the clause imposes, waives, or transfers something the RTA prohibits or reserves. Under RTA s. 3(1) the Act applies despite any agreement to the contrary, and under s. 4(1) a tenancy agreement provision inconsistent with the Act is void — so a clause is non-compliant even if the tenant agreed to it. Typical patterns: transferring the landlord's s. 20 maintenance or repair duties to the tenant (the Act only assigns tenants ordinary cleanliness under s. 33 and damage they cause under s. 34), banning pets in the tenancy agreement (s. 14), charging fees or deposits prohibited by s. 134, requiring a termination notice or agreement at the time of signing (s. 37(4)-(5)), or requiring rent prepayment beyond the one-month rent deposit permitted by s. 106.
+2. "needs_review" — the clause's legality turns on facts not stated in the clause (e.g. amounts versus actual costs, the property type or configuration, or whether a requirement exceeds the tenant's s. 33 ordinary-cleanliness duty), or the clause mixes lawful and unlawful elements.
+3. "compliant" — the clause restates or is consistent with what the Act already provides (e.g. tenant liability for wilful or negligent damage mirrors s. 34; move-out cleaning consistent with ordinary cleanliness mirrors s. 33).
+
+A clause is not compliant merely because it is common practice or because the tenant consented. When a clause imposes obligations beyond what the Act allocates to tenants, do not default to "compliant".
+
 Important nuances in RTA enforcement (LTB case law and guidelines):
 
 - KEY DEPOSITS: While RTA s. 134(1)(a) lists "key deposit" as a prohibited charge, the Landlord and Tenant Board (LTB) has consistently allowed reasonable refundable key deposits limited to the actual replacement cost of keys, fobs, or access cards. A key deposit clause should be assessed as:
@@ -55,7 +63,7 @@ Important nuances in RTA enforcement (LTB case law and guidelines):
 
 - PET DEPOSITS: RTA s. 134(1) prohibits pet deposits entirely. Unlike key deposits, there is no LTB exception for pet deposits. A clause requiring any pet deposit is non-compliant.
 
-- RENT DEPOSITS: Only last month's rent deposit is permitted (RTA s. 106). First month's rent can be collected but is not a "deposit." Any other rent deposit (e.g., "advance rent" beyond last month) should be flagged as needs_review.
+- RENT DEPOSITS: Only last month's rent deposit is permitted (RTA s. 106(2) caps the deposit at one rent period). First month's rent can be collected but is not a "deposit," so requiring first and last month's rent at signing is standard and compliant. A clause that REQUIRES advance rent beyond that (e.g. multiple months prepaid) is non_compliant; treat it as needs_review only where the prepayment is clearly voluntary and tenant-initiated rather than a term the landlord imposed.
 
 - POST-DATED CHEQUES / AUTOMATIC PAYMENTS: RTA s. 108 says a landlord or tenancy agreement cannot require a tenant or prospective tenant to provide post-dated cheques or authorize automatic payment for rent. Clauses that mention post-dated cheques should usually be assessed as "needs_review" unless they clearly frame them as optional and voluntary. Do not mark a clause as automatically non-compliant solely because it mentions post-dated cheques; focus on whether the clause makes that payment method mandatory.`,
   chat: `You are LeaseLens, an AI assistant specializing in Ontario residential tenancy law (the Residential Tenancies Act, 2006).

--- a/src/lib/clause-extractor.ts
+++ b/src/lib/clause-extractor.ts
@@ -9,7 +9,7 @@
 // Falls back to LLM-based extraction for non-standard formats.
 // ---------------------------------------------------------------------------
 
-import { generateObject } from "ai";
+import { generateObject, type LanguageModelUsage } from "ai";
 import { z } from "zod";
 import { openai } from "@/config/llm";
 
@@ -828,7 +828,15 @@ export type ClauseCategory = (typeof VALID_CATEGORIES)[number];
 export async function categorizeClause(
   clauseText: string,
 ): Promise<ClauseCategory> {
-  const { object } = await generateObject({
+  const { category } = await categorizeClauseWithUsage(clauseText);
+  return category;
+}
+
+/** Same as categorizeClause but also surfaces token usage (used by eval tooling). */
+export async function categorizeClauseWithUsage(
+  clauseText: string,
+): Promise<{ category: ClauseCategory; usage: LanguageModelUsage }> {
+  const { object, usage } = await generateObject({
     model: openai("gpt-4o-mini"),
     schema: z.object({
       category: z
@@ -841,5 +849,5 @@ export async function categorizeClause(
     prompt: clauseText,
   });
 
-  return object.category;
+  return { category: object.category, usage };
 }

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -1,4 +1,4 @@
-import { generateObject } from "ai";
+import { generateObject, type LanguageModelUsage } from "ai";
 import { z } from "zod";
 import { analysisModelConfig, systemPrompts } from "@/config/llm";
 
@@ -90,9 +90,18 @@ export async function analyzeClause(
   clause: string,
   legalContext: string[],
 ): Promise<ComplianceResult> {
+  const { result } = await analyzeClauseWithUsage(clause, legalContext);
+  return result;
+}
+
+/** Same as analyzeClause but also surfaces token usage (used by eval tooling). */
+export async function analyzeClauseWithUsage(
+  clause: string,
+  legalContext: string[],
+): Promise<{ result: ComplianceResult; usage: LanguageModelUsage }> {
   const contextBlock = legalContext.join("\n\n");
 
-  const { object } = await generateObject({
+  const { object, usage } = await generateObject({
     model: analysisModelConfig.model,
     schema: complianceResultSchema,
     temperature: analysisModelConfig.temperature,
@@ -101,5 +110,5 @@ export async function analyzeClause(
     prompt: `## Lease clause\n${clause}\n\n## Relevant legal context\n${contextBlock}`,
   });
 
-  return normalizeComplianceResult(clause, object);
+  return { result: normalizeComplianceResult(clause, object), usage };
 }


### PR DESCRIPTION
## Summary

This PR adds an offline evaluation capability for the clause analysis pipeline and lands the first measured quality improvement driven by it.

- Expose token usage from the analysis and categorization calls so evaluation tooling can track cost per run. Existing callers are unchanged.
- Add a benchmark runner (`npm run eval:pilot:run`) that replays the production pipeline (categorization, hybrid retrieval, structured judgment) over a gold dataset and reports retrieval hit rate, citation accuracy, verdict accuracy, flag precision and recall, latency, and cost.
- Codify a statutory decision rubric into the analysis prompt, grounded in RTA ss. 3 and 4: lease provisions inconsistent with the Act are void regardless of consent, so common practice and tenant agreement never make a clause compliant.
- Publish the benchmark report with aggregate results, a model tier comparison, and negative results from two reverted experiments.

## Results

Measured on a 39 clause gold set built from real Ontario lease PDFs, with every label and citation verified against the statute text:

| Metric | Before | After |
|---|---|---|
| Verdict accuracy | 46.2% | 59.0% |
| Problem clause recall | 36.0% | 76.0% |
| Illegal clauses judged compliant | 5 | 0 |
| Citation hit rate | 59.0% | 66.7% |

Methodology and limitations are documented in `docs/eval-pilot-report.md`.

## Notes

- The gold dataset and per sample run records contain private lease text and remain outside the repository (`private_eval/` is gitignored). Only aggregate metrics are published.
- Full test suite passes. The runner was exercised end to end across five benchmark runs.
