### PR TITLE
Fix OOM killed deploy builds on EC2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,11 @@ on:
 env:
   AWS_REGION: ca-central-1
 
+# Serialize deploys so two builds never compete for memory on the instance
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -26,6 +31,16 @@ jobs:
           #!/bin/bash
           set -e
           export HOME=/root
+
+          # Ensure swap exists so npm ci inside the image build cannot be
+          # OOM killed while the app containers are running on the same host
+          if ! swapon --show | grep -q '/swapfile'; then
+            dd if=/dev/zero of=/swapfile bs=1M count=2048
+            chmod 600 /swapfile
+            mkswap /swapfile
+            swapon /swapfile
+          fi
+
           git config --global --add safe.directory /home/ec2-user/LeaseLens
           cd /home/ec2-user/LeaseLens
           git pull origin main

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM node:20-alpine AS deps
 WORKDIR /app
 
 COPY package.json package-lock.json ./
-RUN --mount=type=cache,target=/root/.npm npm ci
+RUN --mount=type=cache,target=/root/.npm npm ci --no-audit --no-fund
 
 # ---- Stage 2: Build the application ----
 FROM node:20-alpine AS builder


### PR DESCRIPTION
## Summary

Deploys to EC2 started failing at the `npm ci` step of the Docker image build with exit code 137 (OOM kill): the instance has no swap, and building the image while the app containers are running exhausts memory. A retry of run 28629468185 thrashed instead of dying and expired the 15 minute poll budget. The change in PR #59 did not touch dependencies, so the install workload is identical to the last successful deploy; the failure is environmental.

## Changes

- Bootstrap a 2G swapfile on the instance (idempotent, runs before the build) so memory pressure degrades to slower builds instead of a SIGKILL.
- Trim `npm ci` with `--no-audit --no-fund` to reduce install work during builds.
- Add a `concurrency` group to the workflow so two deploy runs can never build on the host at the same time.

## Verification

Merging this PR triggers the deploy workflow, which is itself the end to end test: the run should pass the previously failing build step and roll the new containers. The running app is unaffected by the failed deploys because `docker compose up -d --build` only swaps containers after a successful build.
