### PR TITLE
Heal and verify the reverse proxy during deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,6 +86,18 @@ jobs:
           docker compose up -d --build
           docker builder prune -f --filter "until=168h"
           docker image prune -f
+
+          # The reverse proxy can be lost to OOM events and systemd does not
+          # restart it on its own. Heal it and verify the full serving path.
+          if ! systemctl is-active --quiet nginx; then
+            echo "nginx was down, restarting it"
+            systemctl restart nginx
+          fi
+
+          sleep 10
+          curl -sf -o /dev/null http://127.0.0.1:3000/ || { echo "HEALTH FAIL: app not responding on port 3000"; exit 1; }
+          curl -skf -o /dev/null https://127.0.0.1/ || { echo "HEALTH FAIL: nginx not serving HTTPS"; exit 1; }
+          echo "health checks passed: app on 3000, nginx on 443"
           SCRIPT_END
 
           # Convert script to JSON array of commands (one element = entire script)


### PR DESCRIPTION
## Summary

The site went down with connection refused even though the last deploy reported success: host nginx had been killed during an earlier OOM event, systemd does not restart an OOM killed service on its own, and the deploy script only manages the app containers, so the run stayed green while port 443 had no listener.

## Changes

- Restart nginx during deploy when it is not active (self healing edge).
- Add end to end health checks after the containers roll: the deploy now fails loudly if the app does not answer on port 3000 or nginx does not serve HTTPS.

## Verification

Merging triggers the deploy workflow. The run log should show nginx being restarted and the new health check line, and https://leaselens.website should answer again.